### PR TITLE
Introduce basic helper tools

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,47 @@
+on: push
+
+name: Continuous Integration
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - name: build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path lazy_beaver/Cargo.toml
+
+      - name: test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path lazy_beaver/Cargo.toml
+
+      - name: fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --manifest-path lazy_beaver/Cargo.toml -- --check
+
+      - name: clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path lazy_beaver/Cargo.toml -- -D warnings

--- a/lazy_beaver/src/bin.rs
+++ b/lazy_beaver/src/bin.rs
@@ -4,17 +4,34 @@ fn main() {
     let mut max_steps = 10;
     let start = Instant::now();
     for n in 1..=10 {
-        let theory_machines: u64 = (n as u64*4+1).pow(n as u32*2);
-        loop { 
+        let theory_machines: u64 = (n as u64 * 4 + 1).pow(n as u32 * 2);
+        loop {
             let (info, result) = abstract_turing::lazy_beaver_limited(n, max_steps);
             match result {
                 None => {
-                    print!("LB({}) > {} [{}/{}h/{}nh/{}? machines, {}s]\n", n, max_steps, info.0, info.1, info.2, info.0-info.1-info.2, start.elapsed().as_secs());
+                    println!(
+                        "LB({}) > {} [{}/{}h/{}nh/{}? machines, {}s]",
+                        n,
+                        max_steps,
+                        info.0,
+                        info.1,
+                        info.2,
+                        info.0 - info.1 - info.2,
+                        start.elapsed().as_secs()
+                    );
                     max_steps *= 10;
                 }
                 Some(steps) => {
-                    print!("LB({}) = {} [{}/{}h/{}nh/{}? machines, {}s, {}x speedup, {:.2}% unclassified]\n", n, steps, info.0, info.1, info.2, info.0-info.1-info.2, start.elapsed().as_secs(),
-                     theory_machines/info.0, ((info.0-info.1-info.2) as f64)/(info.0 as f64)*100f64);
+                    println!("LB({}) = {} [{}/{}h/{}nh/{}? machines, {}s, {}x speedup, {:.2}% unclassified]",
+                             n,
+                             steps,
+                             info.0,
+                             info.1,
+                             info.2,
+                             info.0-info.1-info.2,
+                             start.elapsed().as_secs(),
+                             theory_machines/info.0,
+                             ((info.0-info.1-info.2) as f64)/(info.0 as f64)*100f64);
                     break;
                 }
             }

--- a/lazy_beaver/src/lib.rs
+++ b/lazy_beaver/src/lib.rs
@@ -1,6 +1,11 @@
+#![deny(clippy::all)]
+#![deny(clippy::pedantic)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::option_option)]
+
+use bit_set::BitSet;
 use std::cmp;
 use std::collections::HashSet;
-use bit_set::BitSet;
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq)]
 enum Direction {
@@ -15,7 +20,7 @@ const MAX_STATES: usize = 10;
 struct ATM {
     max_states: u8,
     next_available_state: u8,
-    transitions: [Option<Option<(State, bool, Direction)>>; MAX_STATES*2],
+    transitions: [Option<Option<(State, bool, Direction)>>; MAX_STATES * 2],
     first_machine_ever: bool,
 }
 
@@ -27,9 +32,9 @@ struct ATMInstance {
 
 // Return true only if we can prove it never halts
 fn cannot_halt(tm: ATM) -> bool {
-    let mut ALL_DIRECTIONS: HashSet<Direction> = HashSet::new();
-    ALL_DIRECTIONS.insert(Direction::Left);
-    ALL_DIRECTIONS.insert(Direction::Right);
+    let mut all_directions: HashSet<Direction> = HashSet::new();
+    all_directions.insert(Direction::Left);
+    all_directions.insert(Direction::Right);
 
     let mut reachable_states: HashSet<Option<u8>> = HashSet::new();
     let mut reachable_directions: HashSet<Direction> = HashSet::new();
@@ -38,21 +43,23 @@ fn cannot_halt(tm: ATM) -> bool {
     loop {
         let mut readable_symbols = HashSet::new();
         readable_symbols.insert(false); // Tape always initialized with zeros
-        if reachable_directions.len() > 1 { readable_symbols.extend(writable_tape_symbols.iter()); }
+        if reachable_directions.len() > 1 {
+            readable_symbols.extend(writable_tape_symbols.iter());
+        }
 
         let mut new_reachable_states = HashSet::new();
         let mut new_reachable_directions = HashSet::new();
         let mut new_writable_tape_symbols = HashSet::new();
 
-        for x in reachable_states.iter() {
+        for x in &reachable_states {
             if let Some(state) = x {
-                for tape_val in readable_symbols.iter() {
-                    let transition = tm.transitions[*state as usize*2+(*tape_val as usize)];
+                for tape_val in &readable_symbols {
+                    let transition = tm.transitions[*state as usize * 2 + (*tape_val as usize)];
                     match transition {
                         None => return false,
                         Some(None) => {
                             new_reachable_states.insert(None);
-                        },
+                        }
                         Some(Some((state, symbol, direction))) => {
                             new_reachable_states.insert(Some(state));
                             new_reachable_directions.insert(direction);
@@ -62,8 +69,11 @@ fn cannot_halt(tm: ATM) -> bool {
                 }
             }
         }
-        if reachable_states.is_superset(&new_reachable_states) && reachable_directions.is_superset(&new_reachable_directions) && writable_tape_symbols.is_superset(&new_writable_tape_symbols) {
-            break
+        if reachable_states.is_superset(&new_reachable_states)
+            && reachable_directions.is_superset(&new_reachable_directions)
+            && writable_tape_symbols.is_superset(&new_writable_tape_symbols)
+        {
+            break;
         } else {
             reachable_states.extend(new_reachable_states);
             reachable_directions.extend(new_reachable_directions);
@@ -83,8 +93,8 @@ enum ExecutionResult {
 fn execute_n_steps(tm: ATM, max_steps: u64) -> ExecutionResult {
     let mut instance = ATMInstance {
         state: 0,
-        head_position: (max_steps+1) as usize,
-        tape: BitSet::with_capacity(max_steps as usize*2+1),
+        head_position: (max_steps + 1) as usize,
+        tape: BitSet::with_capacity(max_steps as usize * 2 + 1),
     };
     //print!("Running a machine for {} steps\n", max_steps);
     if cannot_halt(tm) {
@@ -92,15 +102,15 @@ fn execute_n_steps(tm: ATM, max_steps: u64) -> ExecutionResult {
     }
     for step in 1..=max_steps {
         let symbol_under_head = instance.tape.contains(instance.head_position);
-        let transition_number = (instance.state as usize)*2+(symbol_under_head as usize);
+        let transition_number = (instance.state as usize) * 2 + (symbol_under_head as usize);
         let transition = tm.transitions[transition_number];
         match transition {
             None => {
                 // Non-defined transition encountered. Generate a bunch of more specific machines for each possible machine rule on this transition
                 let mut refinement: Vec<ATM> = Vec::with_capacity(tm.max_states as usize * 4 + 1);
-                
+
                 // (1 machine) Halt on this transition
-                let mut copy = ATM {  
+                let mut copy = ATM {
                     max_states: tm.max_states,
                     next_available_state: tm.next_available_state,
                     transitions: tm.transitions,
@@ -108,29 +118,40 @@ fn execute_n_steps(tm: ATM, max_steps: u64) -> ExecutionResult {
                 };
                 copy.transitions[transition_number] = Some(None);
                 refinement.push(copy);
-                    
+
                 // (2*2*N machines) Don't halt on this transition
-                for write_symbol in [false, true].iter() { // Don't halt on this transition
-                    for move_direction in if tm.first_machine_ever { [Direction::Right].iter() } else { [Direction::Left, Direction::Right].iter()} { // 2x speedup by assuming first move is to the right
-                        for new_state in 0..=tm.next_available_state { // (n-1)! speedup by assuming state X is always accessed before state X+1
+                for write_symbol in &[false, true] {
+                    // Don't halt on this transition
+                    for move_direction in if tm.first_machine_ever {
+                        [Direction::Right].iter()
+                    } else {
+                        [Direction::Left, Direction::Right].iter()
+                    } {
+                        // 2x speedup by assuming first move is to the right
+                        for new_state in 0..=tm.next_available_state {
+                            // (n-1)! speedup by assuming state X is always accessed before state X+1
                             let mut copy = ATM {
                                 max_states: tm.max_states,
-                                next_available_state: cmp::min(cmp::max(new_state+1, tm.next_available_state), tm.max_states-1),
+                                next_available_state: cmp::min(
+                                    cmp::max(new_state + 1, tm.next_available_state),
+                                    tm.max_states - 1,
+                                ),
                                 transitions: tm.transitions,
                                 first_machine_ever: false,
                             };
-                            copy.transitions[transition_number] = Some(Some((new_state, *write_symbol, *move_direction)));
+                            copy.transitions[transition_number] =
+                                Some(Some((new_state, *write_symbol, *move_direction)));
                             refinement.push(copy);
                         }
                     }
                 }
                 //print!("split into {} machines\n", refinement.len());
                 return ExecutionResult::Split(refinement);
-            },
+            }
             Some(None) => {
                 //print!("halted...\n");
                 return ExecutionResult::Halted(step);
-            },
+            }
             Some(Some((new_state, write_symbol, move_direction))) => {
                 //print!(" ran a step...\n");
                 if write_symbol {
@@ -138,18 +159,19 @@ fn execute_n_steps(tm: ATM, max_steps: u64) -> ExecutionResult {
                 } else {
                     instance.tape.remove(instance.head_position);
                 }
-                match move_direction { 
-                    Direction::Left => { instance.head_position -= 1 },
-                    Direction::Right => { instance.head_position += 1 },
+                match move_direction {
+                    Direction::Left => instance.head_position -= 1,
+                    Direction::Right => instance.head_position += 1,
                 };
                 instance.state = new_state;
             }
         }
     }
-    return ExecutionResult::StillRunning; // Didn't halt in max_steps steps
+    ExecutionResult::StillRunning // Didn't halt in max_steps steps
 }
 
 pub type Info = (u64, u64, u64);
+#[must_use]
 pub fn lazy_beaver_limited(states: u8, max_steps: u64) -> (Info, Option<u64>) {
     assert!(states > 0);
     let mut steps_seen: Vec<bool> = vec![false; max_steps as usize];
@@ -158,9 +180,9 @@ pub fn lazy_beaver_limited(states: u8, max_steps: u64) -> (Info, Option<u64>) {
     let mut machines_halted: u64 = 0;
     let mut machines_neverhalt: u64 = 0;
     machines.push(ATM {
-        transitions: [None; MAX_STATES*2],
+        transitions: [None; MAX_STATES * 2],
         max_states: states,
-        next_available_state: cmp::min(states-1, 1),
+        next_available_state: cmp::min(states - 1, 1),
         first_machine_ever: true,
     });
     while let Some(tm) = machines.pop() {
@@ -169,27 +191,29 @@ pub fn lazy_beaver_limited(states: u8, max_steps: u64) -> (Info, Option<u64>) {
         match result {
             ExecutionResult::StillRunning => {
                 // Didn't finish running in max_steps steps
-            },
+            }
             ExecutionResult::Halted(steps) => {
                 steps_seen[steps as usize - 1] = true;
-                machines_halted += 1; 
-            },
-            ExecutionResult::Split(new_machines) => {
-                machines.extend(new_machines)
-            },
+                machines_halted += 1;
+            }
+            ExecutionResult::Split(new_machines) => machines.extend(new_machines),
             ExecutionResult::NeverHalts => {
-                machines_neverhalt += 1; 
-            },
+                machines_neverhalt += 1;
+            }
         }
     }
-    
+
     let info = (machines_seen, machines_halted, machines_neverhalt);
-    (info, steps_seen.iter().position(|x| !x).map(|x| x as u64 + 1))
+    (
+        info,
+        steps_seen.iter().position(|x| !x).map(|x| x as u64 + 1),
+    )
 }
 
+#[must_use]
 pub fn lazy_beaver(states: u8) -> u64 {
     for power in 0.. {
-        if let (_, Some(steps)) = lazy_beaver_limited(states, 10u64.pow(power)) {
+        if let (_, Some(steps)) = lazy_beaver_limited(states, 10_u64.pow(power)) {
             return steps;
         }
     }


### PR DESCRIPTION
This commit introduces a few basics I generally suggest folks use
when writing Rust with repos on Github:

  * lean in on Github Actions
  * make use of Clippy

Rust's [clippy](https://github.com/rust-lang/rust-clippy) is an exceptionally
useful tool and helps catch common coding mistakes, including performance goofs.
I've enabled clippy's pedantic mode here, notabling carving out exception casts.
This code casts u64 to usize in a few places, which works on systems that have 64 bit
words but will break down on smaller machines. My guess would be that the type
can comfortably be a u32 or smaller, but I haven't read deeply yet.

I also have allowed clippy::option_option as I did leave `Option<Option<T>>` in place
in the code, which clippy warns about. Refactoring this to an enum type will be a
larger code change.