### PR TITLE
Introduce criterion benchmark 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,47 @@
+on: push
+
+name: Continuous Integration
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - name: build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path lazy_beaver/Cargo.toml
+
+      - name: test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path lazy_beaver/Cargo.toml
+
+      - name: fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --manifest-path lazy_beaver/Cargo.toml -- --check
+
+      - name: clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path lazy_beaver/Cargo.toml -- -D warnings

--- a/lazy_beaver/Cargo.toml
+++ b/lazy_beaver/Cargo.toml
@@ -16,3 +16,10 @@ path = "src/bin.rs"
 
 [dependencies]
 bit-set = "0.5.0"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "lazy_beaver_limited"
+harness = false

--- a/lazy_beaver/benches/lazy_beaver_limited.rs
+++ b/lazy_beaver/benches/lazy_beaver_limited.rs
@@ -1,0 +1,49 @@
+use abstract_turing::lazy_beaver_limited;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::fmt;
+
+struct Parameters {
+    states: u8,
+    max_steps: u64,
+}
+
+impl fmt::Display for Parameters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({},{})", self.states, self.max_steps)
+    }
+}
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lazy_beaver_limited");
+    for param in &[
+        Parameters {
+            states: 1,
+            max_steps: 10,
+        },
+        Parameters {
+            states: 2,
+            max_steps: 10,
+        },
+        Parameters {
+            states: 3,
+            max_steps: 10,
+        },
+        Parameters {
+            states: 3,
+            max_steps: 100,
+        },
+        Parameters {
+            states: 4,
+            max_steps: 100,
+        },
+    ] {
+        group.bench_with_input(BenchmarkId::from_parameter(param), &param, |b, &param| {
+            b.iter(|| lazy_beaver_limited(param.states, param.max_steps))
+        });
+    }
+}
+
+criterion_group!(name = benches;
+                 config = Criterion::default();
+                 targets = benchmark);
+criterion_main!(benches);

--- a/lazy_beaver/src/bin.rs
+++ b/lazy_beaver/src/bin.rs
@@ -4,17 +4,34 @@ fn main() {
     let mut max_steps = 10;
     let start = Instant::now();
     for n in 1..=10 {
-        let theory_machines: u64 = (n as u64*4+1).pow(n as u32*2);
-        loop { 
+        let theory_machines: u64 = (n as u64 * 4 + 1).pow(n as u32 * 2);
+        loop {
             let (info, result) = abstract_turing::lazy_beaver_limited(n, max_steps);
             match result {
                 None => {
-                    print!("LB({}) > {} [{}/{}h/{}nh/{}? machines, {}s]\n", n, max_steps, info.0, info.1, info.2, info.0-info.1-info.2, start.elapsed().as_secs());
+                    println!(
+                        "LB({}) > {} [{}/{}h/{}nh/{}? machines, {}s]",
+                        n,
+                        max_steps,
+                        info.0,
+                        info.1,
+                        info.2,
+                        info.0 - info.1 - info.2,
+                        start.elapsed().as_secs()
+                    );
                     max_steps *= 10;
                 }
                 Some(steps) => {
-                    print!("LB({}) = {} [{}/{}h/{}nh/{}? machines, {}s, {}x speedup, {:.2}% unclassified]\n", n, steps, info.0, info.1, info.2, info.0-info.1-info.2, start.elapsed().as_secs(),
-                     theory_machines/info.0, ((info.0-info.1-info.2) as f64)/(info.0 as f64)*100f64);
+                    println!("LB({}) = {} [{}/{}h/{}nh/{}? machines, {}s, {}x speedup, {:.2}% unclassified]",
+                             n,
+                             steps,
+                             info.0,
+                             info.1,
+                             info.2,
+                             info.0-info.1-info.2,
+                             start.elapsed().as_secs(),
+                             theory_machines/info.0,
+                             ((info.0-info.1-info.2) as f64)/(info.0 as f64)*100f64);
                     break;
                 }
             }

--- a/lazy_beaver/src/lib.rs
+++ b/lazy_beaver/src/lib.rs
@@ -1,6 +1,11 @@
+#![deny(clippy::all)]
+#![deny(clippy::pedantic)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::option_option)]
+
+use bit_set::BitSet;
 use std::cmp;
 use std::collections::HashSet;
-use bit_set::BitSet;
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq)]
 enum Direction {
@@ -15,7 +20,7 @@ const MAX_STATES: usize = 10;
 struct ATM {
     max_states: u8,
     next_available_state: u8,
-    transitions: [Option<Option<(State, bool, Direction)>>; MAX_STATES*2],
+    transitions: [Option<Option<(State, bool, Direction)>>; MAX_STATES * 2],
     first_machine_ever: bool,
 }
 
@@ -27,9 +32,9 @@ struct ATMInstance {
 
 // Return true only if we can prove it never halts
 fn cannot_halt(tm: ATM) -> bool {
-    let mut ALL_DIRECTIONS: HashSet<Direction> = HashSet::new();
-    ALL_DIRECTIONS.insert(Direction::Left);
-    ALL_DIRECTIONS.insert(Direction::Right);
+    let mut all_directions: HashSet<Direction> = HashSet::new();
+    all_directions.insert(Direction::Left);
+    all_directions.insert(Direction::Right);
 
     let mut reachable_states: HashSet<Option<u8>> = HashSet::new();
     let mut reachable_directions: HashSet<Direction> = HashSet::new();
@@ -38,21 +43,23 @@ fn cannot_halt(tm: ATM) -> bool {
     loop {
         let mut readable_symbols = HashSet::new();
         readable_symbols.insert(false); // Tape always initialized with zeros
-        if reachable_directions.len() > 1 { readable_symbols.extend(writable_tape_symbols.iter()); }
+        if reachable_directions.len() > 1 {
+            readable_symbols.extend(writable_tape_symbols.iter());
+        }
 
         let mut new_reachable_states = HashSet::new();
         let mut new_reachable_directions = HashSet::new();
         let mut new_writable_tape_symbols = HashSet::new();
 
-        for x in reachable_states.iter() {
+        for x in &reachable_states {
             if let Some(state) = x {
-                for tape_val in readable_symbols.iter() {
-                    let transition = tm.transitions[*state as usize*2+(*tape_val as usize)];
+                for tape_val in &readable_symbols {
+                    let transition = tm.transitions[*state as usize * 2 + (*tape_val as usize)];
                     match transition {
                         None => return false,
                         Some(None) => {
                             new_reachable_states.insert(None);
-                        },
+                        }
                         Some(Some((state, symbol, direction))) => {
                             new_reachable_states.insert(Some(state));
                             new_reachable_directions.insert(direction);
@@ -62,8 +69,11 @@ fn cannot_halt(tm: ATM) -> bool {
                 }
             }
         }
-        if reachable_states.is_superset(&new_reachable_states) && reachable_directions.is_superset(&new_reachable_directions) && writable_tape_symbols.is_superset(&new_writable_tape_symbols) {
-            break
+        if reachable_states.is_superset(&new_reachable_states)
+            && reachable_directions.is_superset(&new_reachable_directions)
+            && writable_tape_symbols.is_superset(&new_writable_tape_symbols)
+        {
+            break;
         } else {
             reachable_states.extend(new_reachable_states);
             reachable_directions.extend(new_reachable_directions);
@@ -83,8 +93,8 @@ enum ExecutionResult {
 fn execute_n_steps(tm: ATM, max_steps: u64) -> ExecutionResult {
     let mut instance = ATMInstance {
         state: 0,
-        head_position: (max_steps+1) as usize,
-        tape: BitSet::with_capacity(max_steps as usize*2+1),
+        head_position: (max_steps + 1) as usize,
+        tape: BitSet::with_capacity(max_steps as usize * 2 + 1),
     };
     //print!("Running a machine for {} steps\n", max_steps);
     if cannot_halt(tm) {
@@ -92,15 +102,15 @@ fn execute_n_steps(tm: ATM, max_steps: u64) -> ExecutionResult {
     }
     for step in 1..=max_steps {
         let symbol_under_head = instance.tape.contains(instance.head_position);
-        let transition_number = (instance.state as usize)*2+(symbol_under_head as usize);
+        let transition_number = (instance.state as usize) * 2 + (symbol_under_head as usize);
         let transition = tm.transitions[transition_number];
         match transition {
             None => {
                 // Non-defined transition encountered. Generate a bunch of more specific machines for each possible machine rule on this transition
                 let mut refinement: Vec<ATM> = Vec::with_capacity(tm.max_states as usize * 4 + 1);
-                
+
                 // (1 machine) Halt on this transition
-                let mut copy = ATM {  
+                let mut copy = ATM {
                     max_states: tm.max_states,
                     next_available_state: tm.next_available_state,
                     transitions: tm.transitions,
@@ -108,29 +118,40 @@ fn execute_n_steps(tm: ATM, max_steps: u64) -> ExecutionResult {
                 };
                 copy.transitions[transition_number] = Some(None);
                 refinement.push(copy);
-                    
+
                 // (2*2*N machines) Don't halt on this transition
-                for write_symbol in [false, true].iter() { // Don't halt on this transition
-                    for move_direction in if tm.first_machine_ever { [Direction::Right].iter() } else { [Direction::Left, Direction::Right].iter()} { // 2x speedup by assuming first move is to the right
-                        for new_state in 0..=tm.next_available_state { // (n-1)! speedup by assuming state X is always accessed before state X+1
+                for write_symbol in &[false, true] {
+                    // Don't halt on this transition
+                    for move_direction in if tm.first_machine_ever {
+                        [Direction::Right].iter()
+                    } else {
+                        [Direction::Left, Direction::Right].iter()
+                    } {
+                        // 2x speedup by assuming first move is to the right
+                        for new_state in 0..=tm.next_available_state {
+                            // (n-1)! speedup by assuming state X is always accessed before state X+1
                             let mut copy = ATM {
                                 max_states: tm.max_states,
-                                next_available_state: cmp::min(cmp::max(new_state+1, tm.next_available_state), tm.max_states-1),
+                                next_available_state: cmp::min(
+                                    cmp::max(new_state + 1, tm.next_available_state),
+                                    tm.max_states - 1,
+                                ),
                                 transitions: tm.transitions,
                                 first_machine_ever: false,
                             };
-                            copy.transitions[transition_number] = Some(Some((new_state, *write_symbol, *move_direction)));
+                            copy.transitions[transition_number] =
+                                Some(Some((new_state, *write_symbol, *move_direction)));
                             refinement.push(copy);
                         }
                     }
                 }
                 //print!("split into {} machines\n", refinement.len());
                 return ExecutionResult::Split(refinement);
-            },
+            }
             Some(None) => {
                 //print!("halted...\n");
                 return ExecutionResult::Halted(step);
-            },
+            }
             Some(Some((new_state, write_symbol, move_direction))) => {
                 //print!(" ran a step...\n");
                 if write_symbol {
@@ -138,18 +159,19 @@ fn execute_n_steps(tm: ATM, max_steps: u64) -> ExecutionResult {
                 } else {
                     instance.tape.remove(instance.head_position);
                 }
-                match move_direction { 
-                    Direction::Left => { instance.head_position -= 1 },
-                    Direction::Right => { instance.head_position += 1 },
+                match move_direction {
+                    Direction::Left => instance.head_position -= 1,
+                    Direction::Right => instance.head_position += 1,
                 };
                 instance.state = new_state;
             }
         }
     }
-    return ExecutionResult::StillRunning; // Didn't halt in max_steps steps
+    ExecutionResult::StillRunning // Didn't halt in max_steps steps
 }
 
 pub type Info = (u64, u64, u64);
+#[must_use]
 pub fn lazy_beaver_limited(states: u8, max_steps: u64) -> (Info, Option<u64>) {
     assert!(states > 0);
     let mut steps_seen: Vec<bool> = vec![false; max_steps as usize];
@@ -158,9 +180,9 @@ pub fn lazy_beaver_limited(states: u8, max_steps: u64) -> (Info, Option<u64>) {
     let mut machines_halted: u64 = 0;
     let mut machines_neverhalt: u64 = 0;
     machines.push(ATM {
-        transitions: [None; MAX_STATES*2],
+        transitions: [None; MAX_STATES * 2],
         max_states: states,
-        next_available_state: cmp::min(states-1, 1),
+        next_available_state: cmp::min(states - 1, 1),
         first_machine_ever: true,
     });
     while let Some(tm) = machines.pop() {
@@ -169,27 +191,29 @@ pub fn lazy_beaver_limited(states: u8, max_steps: u64) -> (Info, Option<u64>) {
         match result {
             ExecutionResult::StillRunning => {
                 // Didn't finish running in max_steps steps
-            },
+            }
             ExecutionResult::Halted(steps) => {
                 steps_seen[steps as usize - 1] = true;
-                machines_halted += 1; 
-            },
-            ExecutionResult::Split(new_machines) => {
-                machines.extend(new_machines)
-            },
+                machines_halted += 1;
+            }
+            ExecutionResult::Split(new_machines) => machines.extend(new_machines),
             ExecutionResult::NeverHalts => {
-                machines_neverhalt += 1; 
-            },
+                machines_neverhalt += 1;
+            }
         }
     }
-    
+
     let info = (machines_seen, machines_halted, machines_neverhalt);
-    (info, steps_seen.iter().position(|x| !x).map(|x| x as u64 + 1))
+    (
+        info,
+        steps_seen.iter().position(|x| !x).map(|x| x as u64 + 1),
+    )
 }
 
+#[must_use]
 pub fn lazy_beaver(states: u8) -> u64 {
     for power in 0.. {
-        if let (_, Some(steps)) = lazy_beaver_limited(states, 10u64.pow(power)) {
+        if let (_, Some(steps)) = lazy_beaver_limited(states, 10_u64.pow(power)) {
             return steps;
         }
     }


### PR DESCRIPTION
NOTE: Cannot be merged before #1 is resolved. 

This commit introduces a single criterion benchmark for the
lazy_beaver_limited function. [criterion](https://github.com/bheisler/criterion.rs)
is a benchmarking library with the following advantages over the
bench library that comes with rust:

  * it is usable on stable
  * it makes statistically valid benchmarks
  * it tracks changes over time

I have made no performance improvements to the code. I had considered that
lifting `refinement` out into `lazy_beaver_limited` might improve things as
every call to Vec::new or ::with_capacity incurs an allocation, potentially slow,
especially in a loop. Criterion detected no appreciable change between variants.
Consider also that `cannot_halt` allocates potentially 8 new HashSets each time
it is called, which again might be lifted out. This I did not try. Notice
especially that the interior loop of this function creates 4 HashSets, when they
might be lifted and merely cleared at the start of the loop.

Note that replacing Option<Option<.>> in ATM might improve Rust's optimization changes,
per discussion in #1, which this PR builds on the top of. ATM is also big for a Copy struct.
Because ATM is larger than common machine word size if you pass them around by reference
this will _probably_ end up being faster. The `transitions` field of ATM is the main
contributor to struct size.

My next steps for optimizing this program would be the following:

1. Create benchmarks for the other major functions of this program. Doing so will
give you a sense of where it spends the majority of its runtime.
1. Lift allocations out of functions that are called repeatedly. This will likely
require refactoring into a struct.
1. Remove the Copy derivation on ATM and pass by reference OR shrink the bit size
of `transitions`.
1. Replace Option<Option<.>> with an enum in representative code sample and examine the
respective ASM generated for each variant.
1. Replace HashSet instances over finite domain types with custom bit flag structs.
Note that HashSet<bool> could be represented in a u8 and avoid hash overhead. Lack of
[specialization](rust-lang/rust#31844) mean these new types
can't be generic.